### PR TITLE
Fixes issue #15022 by escaping handcuffs before locked/welded lockers

### DIFF
--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -18,11 +18,11 @@
 			ExtinguishMob()
 		return TRUE
 
-	if(..())
-		return TRUE
-
 	if(handcuffed)
 		spawn() escape_handcuffs()
+	
+	if(..())
+		return TRUE
 
 /mob/living/carbon/proc/escape_handcuffs()
 	//if(!(last_special <= world.time)) return


### PR DESCRIPTION
Due to a logic error in escaping from lockers, being handcuffed counts as incapacitated, thus making it impossible to ever escape from a locked/welded locker if you're handcuffed. This just makes resisting remove handcuffs first, to avoid this issue.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
